### PR TITLE
(VREW-2666) Dropdown can accept different types for value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 declare module "@voyagerx/react-dropdown" {
   import * as React from "react";
-  export interface Option {
+  export interface Option<T = string> {
     label: React.ReactNode;
-    value: string;
+    value: T;
     className?: string;
   }
   export interface Group {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyagerx/react-dropdown",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "React dropdown component",
   "main": "dist/index.js",
   "style": "style.css",


### PR DESCRIPTION
드랍다운의 value 프로퍼티가 제네릭 타입을 받을 수 있도록 수정 했습니다. 기존에 사용하던 코드 코려해서 기본 타입을 string 으로 정해줬습니다.